### PR TITLE
Support mtp_unroll_steps with physical MTP layer reuse

### DIFF
--- a/src/mcore_bridge/config/model_config.py
+++ b/src/mcore_bridge/config/model_config.py
@@ -203,6 +203,9 @@ class ModelConfig(TransformerConfig):
     dsa_indexer_use_sparse_loss: bool = False
     dsa_indexer_rotary_interleaved: bool = False
 
+    # mtp
+    mtp_unroll_steps: Optional[int] = None
+
     # visual
     hf_config: Optional[PretrainedConfig] = None
     vit_attn_impl: Optional[str] = None  # e.g. 'flash_attention_2'

--- a/src/mcore_bridge/config/parser.py
+++ b/src/mcore_bridge/config/parser.py
@@ -47,6 +47,7 @@ config_mapping = {
     'linear_key_head_dim': ['linear_key_head_dim'],
     'linear_value_head_dim': ['linear_value_head_dim'],
     'linear_conv_kernel_dim': ['linear_conv_kernel_dim'],
+    'mtp_unroll_steps': ['mtp_unroll_steps'],
     # dsa
     'dsa_indexer_n_heads': ['index_n_heads'],
     'dsa_indexer_head_dim': ['index_head_dim'],

--- a/src/mcore_bridge/model/gpt_model.py
+++ b/src/mcore_bridge/model/gpt_model.py
@@ -407,7 +407,7 @@ class GPTModel(McoreGPTModel):
             mtp_depth = getattr(self.config, 'mtp_unroll_steps', None) or self.config.mtp_num_layers
             mtp_extra_block_kwargs = dict(extra_block_kwargs or {})
             if self.config.is_multimodal and decoder_input is not None:
-                mtp_extra_block_kwargs['base_decoder_input'] = decoder_input.detach()
+                mtp_extra_block_kwargs['base_decoder_input'] = decoder_input
             hidden_states = self.mtp(
                 input_ids=input_ids,
                 position_ids=position_ids,

--- a/src/mcore_bridge/model/gpt_model.py
+++ b/src/mcore_bridge/model/gpt_model.py
@@ -404,10 +404,10 @@ class GPTModel(McoreGPTModel):
             input_ids = split_cp_inputs(input_ids, getattr(packed_seq_params, 'cu_seqlens_q', None), 1)
 
         if self.mtp_process and labels is not None:
-            if self.config.is_multimodal:
-                embedding_ = (self.embedding, decoder_input)
-            else:
-                embedding_ = self.embedding
+            mtp_depth = getattr(self.config, 'mtp_unroll_steps', None) or self.config.mtp_num_layers
+            mtp_extra_block_kwargs = dict(extra_block_kwargs or {})
+            if self.config.is_multimodal and decoder_input is not None:
+                mtp_extra_block_kwargs['base_decoder_input'] = decoder_input.detach()
             hidden_states = self.mtp(
                 input_ids=input_ids,
                 position_ids=position_ids,
@@ -419,16 +419,16 @@ class GPTModel(McoreGPTModel):
                 rotary_pos_sin=rotary_pos_sin,
                 packed_seq_params=packed_seq_params,
                 sequence_len_offset=sequence_len_offset,
-                embedding=embedding_,
-                **(extra_block_kwargs or {}),
+                embedding=self.embedding,
+                extra_block_kwargs=mtp_extra_block_kwargs or None,
             )
             mtp_labels = labels.clone()
-            hidden_states_list = torch.chunk(hidden_states, 1 + self.config.mtp_num_layers, dim=0)
+            hidden_states_list = torch.chunk(hidden_states, 1 + mtp_depth, dim=0)
             hidden_states = hidden_states_list[0]
             if loss_mask is None:
                 # if loss_mask is not provided, use all ones as loss_mask
                 loss_mask = torch.ones_like(mtp_labels)
-            for mtp_layer_number in range(self.config.mtp_num_layers):
+            for mtp_layer_number in range(mtp_depth):
                 # output
                 mtp_logits, _ = self.output_layer(
                     hidden_states_list[mtp_layer_number + 1],
@@ -460,10 +460,10 @@ class GPTModel(McoreGPTModel):
                     MTPLossLoggingHelper.save_loss_to_tracker(
                         mtp_loss_for_log,
                         mtp_layer_number,
-                        self.config.mtp_num_layers,
+                        mtp_depth,
                         avg_group=parallel_state.get_data_parallel_group(with_context_parallel=True),
                     )
-                mtp_loss_scale = self.config.mtp_loss_scaling_factor / self.config.mtp_num_layers
+                mtp_loss_scale = self.config.mtp_loss_scaling_factor / mtp_depth
                 if self.config.calculate_per_token_loss:
                     hidden_states = MTPLossAutoScaler.apply(hidden_states, mtp_loss_scale * mtp_loss)
                 else:

--- a/src/mcore_bridge/patcher.py
+++ b/src/mcore_bridge/patcher.py
@@ -383,13 +383,14 @@ def _patch_mtp():
     def _shift_decoder_input(
         decoder_input: torch.Tensor,
         cp_group,
+        shifts: int = -1,
         packed_seq_params: PackedSeqParams = None,
     ) -> torch.Tensor:
         # Convert [s, b, h] -> [b, h, s] so roll_tensor can operate on the sequence dimension.
         decoder_input = decoder_input.permute(1, 2, 0).contiguous()
         decoder_input, _ = roll_tensor(
             decoder_input,
-            shifts=-1,
+            shifts=shifts,
             dims=-1,
             cp_group=cp_group,
             packed_seq_params=packed_seq_params,
@@ -468,12 +469,12 @@ def _patch_mtp():
             enable_sp = self.config.sequence_parallel and self.config.tensor_model_parallel_size > 1
             if enable_sp:
                 decoder_input = gather_from_sequence_parallel_region(decoder_input)
-            for _ in range(effective_depth):
-                decoder_input = _shift_decoder_input(
-                    decoder_input,
-                    cp_group=self.cp_group,
-                    packed_seq_params=packed_seq_params,
-                )
+            decoder_input = _shift_decoder_input(
+                decoder_input,
+                cp_group=self.cp_group,
+                shifts=-effective_depth,
+                packed_seq_params=packed_seq_params,
+            )
             if enable_sp:
                 decoder_input = scatter_to_sequence_parallel_region(decoder_input)
             hidden_states = make_viewless_tensor(inp=hidden_states, requires_grad=True, keep_graph=True)

--- a/src/mcore_bridge/patcher.py
+++ b/src/mcore_bridge/patcher.py
@@ -377,6 +377,24 @@ def _patch_TEGroupedLinear():
 
 
 def _patch_mtp():
+    from megatron.core.transformer.multi_token_prediction import MultiTokenPredictionBlock, get_mtp_layer_offset, \
+        roll_tensor
+
+    def _shift_decoder_input(
+        decoder_input: torch.Tensor,
+        cp_group,
+        packed_seq_params: PackedSeqParams = None,
+    ) -> torch.Tensor:
+        # Convert [s, b, h] -> [b, h, s] so roll_tensor can operate on the sequence dimension.
+        decoder_input = decoder_input.permute(1, 2, 0).contiguous()
+        decoder_input, _ = roll_tensor(
+            decoder_input,
+            shifts=-1,
+            dims=-1,
+            cp_group=cp_group,
+            packed_seq_params=packed_seq_params,
+        )
+        return decoder_input.permute(2, 0, 1).contiguous()
 
     def forward(
         self,
@@ -394,6 +412,8 @@ def _patch_mtp():
         packed_seq_params: PackedSeqParams = None,
         sequence_len_offset: torch.Tensor = None,
         embedding=None,
+        base_decoder_input: torch.Tensor = None,
+        depth_idx: int = None,
     ):
         """
         Execute the forward pass through the Multi-Token Prediction (MTP) layer.
@@ -417,15 +437,46 @@ def _patch_mtp():
             Union[Tensor, Tuple[Tensor, Tensor]]: The output hidden states tensor of shape
             [s, b, h], and optionally the updated context tensor if cross-attention is used.
         """
-        # TODO: Multimodal compatible
+        from megatron.core.utils import make_viewless_tensor
+
+        effective_depth = self.layer_number if depth_idx is None else depth_idx
         assert context is None, 'multi token prediction + cross attention is not yet supported.'
-        input_ids, position_ids, decoder_input, hidden_states = self._get_embeddings(
-            input_ids=input_ids,
-            position_ids=position_ids,
-            embedding=embedding,
-            packed_seq_params=packed_seq_params,
-            hidden_states=hidden_states,
-        )
+        if base_decoder_input is None:
+            input_ids, position_ids, decoder_input, hidden_states = self._get_embeddings(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                embedding=embedding,
+                packed_seq_params=packed_seq_params,
+                hidden_states=hidden_states,
+            )
+        else:
+            input_ids, _ = roll_tensor(
+                input_ids,
+                shifts=-1,
+                dims=-1,
+                cp_group=self.cp_group,
+                packed_seq_params=packed_seq_params,
+            )
+            position_ids, _ = roll_tensor(
+                position_ids,
+                shifts=-1,
+                dims=-1,
+                cp_group=self.cp_group,
+                packed_seq_params=packed_seq_params,
+            )
+            decoder_input = base_decoder_input
+            enable_sp = self.config.sequence_parallel and self.config.tensor_model_parallel_size > 1
+            if enable_sp:
+                decoder_input = gather_from_sequence_parallel_region(decoder_input)
+            for _ in range(effective_depth):
+                decoder_input = _shift_decoder_input(
+                    decoder_input,
+                    cp_group=self.cp_group,
+                    packed_seq_params=packed_seq_params,
+                )
+            if enable_sp:
+                decoder_input = scatter_to_sequence_parallel_region(decoder_input)
+            hidden_states = make_viewless_tensor(inp=hidden_states, requires_grad=True, keep_graph=True)
         assert not self.transformer_layer.self_attention.config.apply_rope_fusion
         packed_seq = packed_seq_params is not None and packed_seq_params.qkv_format == 'thd'
         if self.config.position_embedding_type == 'rope' and packed_seq:
@@ -433,7 +484,7 @@ def _patch_mtp():
             rotary_pos_emb = rotary_pos_emb[position_ids[0]]
         else:
             # mrope or not packed_seq
-            rotary_pos_emb = torch.roll(rotary_pos_emb, shifts=-self.layer_number, dims=0)
+            rotary_pos_emb = torch.roll(rotary_pos_emb, shifts=-effective_depth, dims=0)
         if self.config.recompute_granularity == 'full' and self.training:
             hidden_states = self._checkpointed_forward(
                 partial(
@@ -471,6 +522,57 @@ def _patch_mtp():
 
     MultiTokenPredictionLayer.forward = forward
 
+    def block_forward(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor,
+        context: torch.Tensor = None,
+        context_mask: torch.Tensor = None,
+        rotary_pos_emb: torch.Tensor = None,
+        rotary_pos_cos: torch.Tensor = None,
+        rotary_pos_sin: torch.Tensor = None,
+        attention_bias: torch.Tensor = None,
+        inference_params: InferenceParams = None,
+        packed_seq_params: PackedSeqParams = None,
+        sequence_len_offset: torch.Tensor = None,
+        extra_block_kwargs: Optional[dict] = None,
+        embedding=None,
+    ):
+        """Perform the forward pass through all MTP modules with optional layer reuse."""
+        offset = get_mtp_layer_offset(self.config, self.vp_stage)
+        hidden_states_list = list(torch.chunk(hidden_states, 1 + offset, dim=0))
+        hidden_states = hidden_states_list[offset]
+
+        physical_num_layers = len(self.layers)
+        unroll_steps = getattr(self.config, 'mtp_unroll_steps', None) or self.config.mtp_num_layers
+
+        for step in range(unroll_steps):
+            layer = self.layers[step % physical_num_layers]
+            global_depth = offset + step + 1
+            hidden_states, input_ids, position_ids = layer(
+                input_ids=input_ids,
+                position_ids=position_ids,
+                hidden_states=hidden_states,
+                attention_mask=attention_mask,
+                inference_params=inference_params,
+                rotary_pos_emb=rotary_pos_emb,
+                rotary_pos_cos=rotary_pos_cos,
+                rotary_pos_sin=rotary_pos_sin,
+                packed_seq_params=packed_seq_params,
+                sequence_len_offset=sequence_len_offset,
+                embedding=embedding,
+                depth_idx=global_depth,
+                **(extra_block_kwargs or {}),
+            )
+            hidden_states_list.append(hidden_states)
+
+        hidden_states = torch.cat(hidden_states_list, dim=0)
+        return hidden_states
+
+    MultiTokenPredictionBlock.forward = block_forward
+
     def _get_embeddings(
         self,
         input_ids: torch.Tensor,
@@ -479,7 +581,6 @@ def _patch_mtp():
         hidden_states: torch.Tensor,
         packed_seq_params: Optional[PackedSeqParams] = None,
     ):
-        from megatron.core.transformer.multi_token_prediction import roll_tensor
         from megatron.core.utils import make_viewless_tensor
 
         # Calc logits for the current Multi-Token Prediction (MTP) layers.

--- a/tests/test_mtp_unroll.py
+++ b/tests/test_mtp_unroll.py
@@ -1,0 +1,62 @@
+import types
+
+import torch
+from transformers import PretrainedConfig
+
+from mcore_bridge.config import hf_to_mcore_config
+from megatron.core.transformer.multi_token_prediction import MultiTokenPredictionBlock
+
+
+class DummyConfig(PretrainedConfig):
+    model_type = 'dummy'
+
+
+class RecorderLayer:
+
+    def __init__(self, tag: int):
+        self.tag = tag
+        self.calls = []
+
+    def __call__(self, hidden_states, input_ids, position_ids, depth_idx=None, **kwargs):
+        self.calls.append(depth_idx)
+        return hidden_states + self.tag + depth_idx, input_ids, position_ids
+
+
+def test_hf_to_mcore_config_reads_mtp_unroll_steps():
+    config = DummyConfig()
+    config.mtp_unroll_steps = 4
+
+    res = hf_to_mcore_config(config)
+
+    assert res['mtp_unroll_steps'] == 4
+
+
+def test_mtp_block_reuses_physical_layers_for_unroll_steps():
+    layer0 = RecorderLayer(10)
+    layer1 = RecorderLayer(20)
+    block = types.SimpleNamespace(
+        config=types.SimpleNamespace(
+            mtp_num_layers=2,
+            mtp_unroll_steps=5,
+            pipeline_model_parallel_size=1,
+            pipeline_model_parallel_layout=None,
+        ),
+        vp_stage=None,
+        layers=[layer0, layer1],
+    )
+    hidden_states = torch.zeros(2, 1, 1)
+    input_ids = torch.zeros(1, 2, dtype=torch.long)
+    position_ids = torch.zeros(1, 2, dtype=torch.long)
+    attention_mask = torch.zeros(1, 1, 2, 2, dtype=torch.bool)
+
+    outputs = MultiTokenPredictionBlock.forward(
+        block,
+        input_ids=input_ids,
+        position_ids=position_ids,
+        hidden_states=hidden_states,
+        attention_mask=attention_mask,
+    )
+
+    assert layer0.calls == [1, 3, 5]
+    assert layer1.calls == [2, 4]
+    assert outputs.shape[0] == hidden_states.shape[0] * (1 + block.config.mtp_unroll_steps)

--- a/tests/test_mtp_unroll.py
+++ b/tests/test_mtp_unroll.py
@@ -1,9 +1,11 @@
 import types
 
+import pytest
 import torch
 from transformers import PretrainedConfig
 
 from mcore_bridge.config import hf_to_mcore_config
+from mcore_bridge.model.gpt_model import GPTModel
 from megatron.core.transformer.multi_token_prediction import MultiTokenPredictionBlock
 
 
@@ -60,3 +62,48 @@ def test_mtp_block_reuses_physical_layers_for_unroll_steps():
     assert layer0.calls == [1, 3, 5]
     assert layer1.calls == [2, 4]
     assert outputs.shape[0] == hidden_states.shape[0] * (1 + block.config.mtp_unroll_steps)
+
+
+def test_multimodal_mtp_reuses_decoder_input_without_detach():
+    captured = {}
+
+    class StopMTP(RuntimeError):
+        pass
+
+    def mtp(**kwargs):
+        captured.update(kwargs.get('extra_block_kwargs') or {})
+        raise StopMTP
+
+    model = types.SimpleNamespace(
+        post_process=True,
+        config=types.SimpleNamespace(
+            task_type='causal_lm',
+            is_multimodal=True,
+            context_parallel_size=1,
+            mtp_num_layers=1,
+            mtp_unroll_steps=None,
+        ),
+        training=True,
+        share_embeddings_and_output_weights=False,
+        mtp_process=True,
+        mtp=mtp,
+        embedding=object(),
+    )
+    decoder_input = torch.randn(2, 1, 4, requires_grad=True)
+
+    with pytest.raises(StopMTP):
+        GPTModel._postprocess(
+            model,
+            hidden_states=torch.randn(2, 1, 4),
+            input_ids=torch.zeros(1, 2, dtype=torch.long),
+            position_ids=torch.zeros(1, 2, dtype=torch.long),
+            labels=torch.zeros(1, 2, dtype=torch.long),
+            rotary_pos_emb=torch.zeros(2, 1, 4),
+            rotary_pos_cos=None,
+            rotary_pos_sin=None,
+            decoder_input=decoder_input,
+            attention_mask=torch.zeros(1, 1, 2, 2, dtype=torch.bool),
+        )
+
+    assert captured['base_decoder_input'] is decoder_input
+    assert captured['base_decoder_input'].requires_grad


### PR DESCRIPTION
## Summary
- add `mtp_unroll_steps` to decouple MTP unroll depth from physical MTP layer count
- reuse physical MTP layers in round-robin mode during MTP unroll
- reuse multimodal `decoder_input` in the MTP path so multimodal MTP follows the same unroll flow
- keep default behavior unchanged when `mtp_unroll_steps` is unset
- add tests for config parsing and physical-layer reuse behavior

## Motivation
Current `mcore-bridge` MTP behavior ties the effective MTP depth to the number of physical MTP layers. This makes it hard to support deeper MTP unroll while reusing a smaller set of physical layers, which is useful for Qwen3.5 multimodal MTP experiments and keeps the patch focused inside `mcore-bridge`.

This change introduces `mtp_unroll_steps` as an optional logical unroll depth. When it is set, MTP forward uses that depth while reusing physical MTP layers in round-robin mode. When it is unset, behavior remains the same as before.

The patch also reuses multimodal `decoder_input` in the MTP path so multimodal MTP follows the same reuse/unroll logic.

## Compatibility
- default behavior is unchanged if `mtp_unroll_steps` is not set
- current MTP loss scaling semantics are preserved by normalizing with effective MTP depth
- patch scope is limited to `mcore-bridge`

## Testing
- `PYTHONPATH=../mcore-bridge/src /data/ENV/miniconda3/envs/SWIFT/bin/python -m pytest ../mcore-bridge/tests/test_mtp_unroll.py -q`
- `/data/ENV/miniconda3/envs/SWIFT/bin/python -m compileall src/mcore_bridge tests/test_mtp_unroll.py`

---

## 中文说明

### 变更概述
- 新增 `mtp_unroll_steps`，用于将 MTP 的展开深度与物理 MTP 层数解耦
- 在 MTP unroll 过程中按 round-robin 方式复用物理 MTP 层
- 在多模态 MTP 路径上复用 `decoder_input`，使其与同样的 reuse/unroll 流程对齐
- 当未设置 `mtp_unroll_steps` 时，保持原有行为不变
- 增加了配置解析和物理层复用相关测试

### 修改动机
当前 `mcore-bridge` 的 MTP 深度与物理 MTP 层数是绑定的，不利于在只增加少量物理层的情况下做更深的 MTP 展开。对于 Qwen3.5 的多模态 MTP 场景，我们希望先在 `mcore-bridge` 内完成第一阶段支持，以尽量减少对上层仓库的改动范围。

因此这次改动引入可选参数 `mtp_unroll_steps` 作为逻辑展开深度；当设置该参数时，前向中使用该深度，并通过 round-robin 方式复用物理 MTP 层；不设置时则完全保持原有逻辑。

同时，这个 patch 也补齐了多模态 MTP 路径上的 `decoder_input` 复用，使多模态场景下的 MTP 能走同样的 unroll/reuse 逻辑。

### 兼容性说明
- 未设置 `mtp_unroll_steps` 时，默认行为不变
- 当前 MTP loss scaling 语义保持不变，仍按 effective MTP depth 做归一化
- patch 范围限制在 `mcore-bridge` 内，适合作为第一阶段 MR

### 测试
- `PYTHONPATH=../mcore-bridge/src /data/ENV/miniconda3/envs/SWIFT/bin/python -m pytest ../mcore-bridge/tests/test_mtp_unroll.py -q`
- `/data/ENV/miniconda3/envs/SWIFT/bin/python -m compileall src/mcore_bridge tests/test_mtp_unroll.py`
