### PR TITLE
fix: Add is_mtp parameter to _set_moe_state avoid type error

### DIFF
--- a/src/mcore_bridge/model/gpts/minimax_m2.py
+++ b/src/mcore_bridge/model/gpts/minimax_m2.py
@@ -80,14 +80,14 @@ class MinimaxM2Bridge(GPTBridge):
         hf_prefix: str,
         layer_idx: int,
         to_mcore: bool,
-        is_mtp: bool,
+        is_mtp: bool = False,
     ):
         if to_mcore:
             hf_state_dict = {
                 k.replace('.w1.', '.gate_proj.').replace('.w3.', '.up_proj.').replace('.w2.', '.down_proj.'): v
                 for k, v in hf_state_dict.items()
             }
-        hf_state_dict = super()._set_moe_state(mg_mlp, hf_state_dict, hf_prefix, layer_idx, to_mcore)
+        hf_state_dict = super()._set_moe_state(mg_mlp, hf_state_dict, hf_prefix, layer_idx, to_mcore, is_mtp)
         if not to_mcore:
             hf_state_dict = {
                 k.replace('.gate_proj.', '.w1.').replace('.up_proj.', '.w3.').replace('.down_proj.', '.w2.'): v

--- a/src/mcore_bridge/model/gpts/minimax_m2.py
+++ b/src/mcore_bridge/model/gpts/minimax_m2.py
@@ -80,6 +80,7 @@ class MinimaxM2Bridge(GPTBridge):
         hf_prefix: str,
         layer_idx: int,
         to_mcore: bool,
+        is_mtp: bool,
     ):
         if to_mcore:
             hf_state_dict = {


### PR DESCRIPTION
MinimaxM2Bridge类继承了GPTBridge类，但是其_set_moe_state的签名与GPTBridge类的不一致，缺少is_mtp变量。导致报错TypeError: MinimaxM2Bridge._set_moe_state() got an unexpected keyword argument 'is_mtp'。

这里由于MinimaxM2Bridge类的_set_moe_state方法体没有实际使用is_mtp变量，且在GPTBridge类中有mtp处理逻辑，所以直接在形参中添加is_mtp变量即可。

修改后，在NPU测试可正常训练Minimax M2.5。