### PR TITLE
npu  qwen3.5 megatron padding_free fix

### DIFF
--- a/src/mcore_bridge/model/gpts/qwen3_next.py
+++ b/src/mcore_bridge/model/gpts/qwen3_next.py
@@ -59,7 +59,7 @@ except ImportError:
 logger = get_logger()
 
 
-def resolve_hf_attention_mask(kwargs) -> Optional[torch.Tensor]:
+def resolve_gdn_attention_mask(kwargs) -> Optional[torch.Tensor]:
     if is_torch_npu_available():
         attention_mask = kwargs.get('attention_mask_2d')
         if attention_mask is not None:

--- a/src/mcore_bridge/model/gpts/qwen3_next.py
+++ b/src/mcore_bridge/model/gpts/qwen3_next.py
@@ -67,9 +67,7 @@ def resolve_gdn_attention_mask(kwargs) -> Optional[torch.Tensor]:
     attention_mask = kwargs.get('attention_mask')
     if attention_mask is None:
         return None
-    if attention_mask.ndim == 4:
-        return (~attention_mask).sum(dim=(1, 2)) > 0
-    return attention_mask.to(torch.bool)
+    return (~attention_mask).sum(dim=(1, 2)) > 0
 
 
 class Qwen3NextRMSNorm(torch.nn.Module):

--- a/src/mcore_bridge/model/gpts/qwen3_next.py
+++ b/src/mcore_bridge/model/gpts/qwen3_next.py
@@ -17,8 +17,8 @@ from megatron.core.transformer.spec_utils import build_module
 from megatron.core.transformer.transformer_block import TransformerBlockSubmodules
 from megatron.core.utils import deprecate_inference_params, is_fa_min_version
 from packaging import version
-from typing import Optional, Tuple, Union
 from transformers.utils import is_torch_npu_available
+from typing import Optional, Tuple, Union
 
 from mcore_bridge.bridge import GPTBridge
 from mcore_bridge.config import ModelConfig

--- a/src/mcore_bridge/model/gpts/qwen3_next.py
+++ b/src/mcore_bridge/model/gpts/qwen3_next.py
@@ -59,7 +59,7 @@ except ImportError:
 logger = get_logger()
 
 
-def _get_hf_attention_mask(kwargs) -> Optional[torch.Tensor]:
+def resolve_hf_attention_mask(kwargs) -> Optional[torch.Tensor]:
     if is_torch_npu_available():
         attention_mask = kwargs.get('attention_mask_2d')
         if attention_mask is not None:
@@ -499,7 +499,7 @@ class Qwen3NextGatedDeltaNet(_HuggingFaceModule, _Qwen3NextGatedDeltaNet):
             hidden_states = new_hidden_states
         else:
             hidden_states = hidden_states.transpose(0, 1)
-            attention_mask = _get_hf_attention_mask(kwargs)
+            attention_mask = resolve_hf_attention_mask(kwargs)
         res = super().forward(hidden_states=hidden_states, attention_mask=attention_mask)
         if thd_format:
             res = res[attention_mask][:, None]

--- a/src/mcore_bridge/model/gpts/qwen3_next.py
+++ b/src/mcore_bridge/model/gpts/qwen3_next.py
@@ -18,6 +18,7 @@ from megatron.core.transformer.transformer_block import TransformerBlockSubmodul
 from megatron.core.utils import deprecate_inference_params, is_fa_min_version
 from packaging import version
 from typing import Optional, Tuple, Union
+from transformers.utils import is_torch_npu_available
 
 from mcore_bridge.bridge import GPTBridge
 from mcore_bridge.config import ModelConfig
@@ -56,6 +57,19 @@ except ImportError:
     SplitAlongDim = None
 
 logger = get_logger()
+
+
+def _get_hf_attention_mask(kwargs) -> Optional[torch.Tensor]:
+    if is_torch_npu_available():
+        attention_mask = kwargs.get('attention_mask_2d')
+        if attention_mask is not None:
+            return attention_mask.to(torch.bool)
+    attention_mask = kwargs.get('attention_mask')
+    if attention_mask is None:
+        return None
+    if attention_mask.ndim == 4:
+        return (~attention_mask).sum(dim=(1, 2)) > 0
+    return attention_mask.to(torch.bool)
 
 
 class Qwen3NextRMSNorm(torch.nn.Module):
@@ -485,9 +499,7 @@ class Qwen3NextGatedDeltaNet(_HuggingFaceModule, _Qwen3NextGatedDeltaNet):
             hidden_states = new_hidden_states
         else:
             hidden_states = hidden_states.transpose(0, 1)
-            attention_mask = kwargs.get('attention_mask')
-            if attention_mask is not None:
-                attention_mask = (~attention_mask).sum(dim=(1, 2)) > 0
+            attention_mask = _get_hf_attention_mask(kwargs)
         res = super().forward(hidden_states=hidden_states, attention_mask=attention_mask)
         if thd_format:
             res = res[attention_mask][:, None]

--- a/src/mcore_bridge/model/mm_gpts/qwen3_5.py
+++ b/src/mcore_bridge/model/mm_gpts/qwen3_5.py
@@ -10,7 +10,7 @@ from megatron.core.transformer.transformer_config import TransformerConfig
 from mcore_bridge.utils import get_env_args
 
 from ..constant import ModelType
-from ..gpts.qwen3_next import Qwen3NextBridge, Qwen3NextLoader, resolve_hf_attention_mask
+from ..gpts.qwen3_next import Qwen3NextBridge, Qwen3NextLoader, resolve_gdn_attention_mask
 from ..register import ModelMeta, register_model
 from .utils import HuggingFaceVit
 
@@ -52,7 +52,7 @@ class Qwen3_5MoeGatedDeltaNet(_HuggingFaceModule, _Qwen3_5MoeGatedDeltaNet):
             hidden_states = new_hidden_states
         else:
             hidden_states = hidden_states.transpose(0, 1)
-            attention_mask = resolve_hf_attention_mask(kwargs)
+            attention_mask = resolve_gdn_attention_mask(kwargs)
         res = super().forward(hidden_states=hidden_states, attention_mask=attention_mask)
         if thd_format:
             res = res[attention_mask][:, None]

--- a/src/mcore_bridge/model/mm_gpts/qwen3_5.py
+++ b/src/mcore_bridge/model/mm_gpts/qwen3_5.py
@@ -10,7 +10,7 @@ from megatron.core.transformer.transformer_config import TransformerConfig
 from mcore_bridge.utils import get_env_args
 
 from ..constant import ModelType
-from ..gpts.qwen3_next import Qwen3NextBridge, Qwen3NextLoader, _get_hf_attention_mask
+from ..gpts.qwen3_next import Qwen3NextBridge, Qwen3NextLoader, resolve_hf_attention_mask
 from ..register import ModelMeta, register_model
 from .utils import HuggingFaceVit
 
@@ -52,7 +52,7 @@ class Qwen3_5MoeGatedDeltaNet(_HuggingFaceModule, _Qwen3_5MoeGatedDeltaNet):
             hidden_states = new_hidden_states
         else:
             hidden_states = hidden_states.transpose(0, 1)
-            attention_mask = _get_hf_attention_mask(kwargs)
+            attention_mask = resolve_hf_attention_mask(kwargs)
         res = super().forward(hidden_states=hidden_states, attention_mask=attention_mask)
         if thd_format:
             res = res[attention_mask][:, None]

--- a/src/mcore_bridge/model/mm_gpts/qwen3_5.py
+++ b/src/mcore_bridge/model/mm_gpts/qwen3_5.py
@@ -10,7 +10,7 @@ from megatron.core.transformer.transformer_config import TransformerConfig
 from mcore_bridge.utils import get_env_args
 
 from ..constant import ModelType
-from ..gpts.qwen3_next import Qwen3NextBridge, Qwen3NextLoader
+from ..gpts.qwen3_next import Qwen3NextBridge, Qwen3NextLoader, _get_hf_attention_mask
 from ..register import ModelMeta, register_model
 from .utils import HuggingFaceVit
 
@@ -52,9 +52,7 @@ class Qwen3_5MoeGatedDeltaNet(_HuggingFaceModule, _Qwen3_5MoeGatedDeltaNet):
             hidden_states = new_hidden_states
         else:
             hidden_states = hidden_states.transpose(0, 1)
-            attention_mask = kwargs.get('attention_mask')
-            if attention_mask is not None:
-                attention_mask = (~attention_mask).sum(dim=(1, 2)) > 0
+            attention_mask = _get_hf_attention_mask(kwargs)
         res = super().forward(hidden_states=hidden_states, attention_mask=attention_mask)
         if thd_format:
             res = res[attention_mask][:, None]


### PR DESCRIPTION
## Problem

For Qwen3.5 / Qwen3-Next on NPU, `padding_free=False` may fail in the GDN non-thd path, while `padding_free=True` works only because the thd path derives mask from `cu_seqlens_q` internally and bypasses the broken external mask chain. :contentReference[oaicite:2]{index=2}

## Cause

The GDN non-thd branch reads external mask from kwargs, but on NPU the correct mask for this path is `attention_mask_2d`. Without preferring that field, the model may consume an incompatible mask. :contentReference[oaicite:3]{index=3}

## Fix

This PR updates the Qwen GDN non-thd path to prefer `attention_mask_2d` on NPU and fall back to the original `attention_mask` behavior otherwise.

## Notes

This is the model-side half of the fix. It is intended to work together with the `ms-swift` trainer-side change that preserves `attention_mask_2d`.