### PR TITLE
[bugfix] fix tie_word_embeddings

### DIFF
--- a/src/mcore_bridge/config/parser.py
+++ b/src/mcore_bridge/config/parser.py
@@ -98,7 +98,8 @@ def _convert_config(config, _internal_call=False) -> Dict[str, Any]:
             # fix Qwen/Qwen3-VL-30B-A3B-Thinking
             untie_embeddings_and_output_weights = megatron_config.get('untie_embeddings_and_output_weights')
             megatron_config.update(_convert_config(getattr(config, key), _internal_call=True))
-            megatron_config['untie_embeddings_and_output_weights'] = untie_embeddings_and_output_weights
+            if untie_embeddings_and_output_weights is not None:
+                megatron_config['untie_embeddings_and_output_weights'] = untie_embeddings_and_output_weights
     # compat llama3
     if getattr(config, 'rope_scaling', None) is not None:
         if isinstance(config.rope_scaling, int):

--- a/src/mcore_bridge/config/parser.py
+++ b/src/mcore_bridge/config/parser.py
@@ -93,13 +93,13 @@ def _convert_config(config, _internal_call=False) -> Dict[str, Any]:
                             k = 'llm_model_type'
                     megatron_config[k] = hf_v
                 break
+    # fix Qwen/Qwen3-VL-30B-A3B-Thinking
+    untie_embeddings_and_output_weights = megatron_config.get('untie_embeddings_and_output_weights')
     for key in ['text_config', 'llm_config', 'thinker_config']:
         if hasattr(config, key):
-            # fix Qwen/Qwen3-VL-30B-A3B-Thinking
-            untie_embeddings_and_output_weights = megatron_config.get('untie_embeddings_and_output_weights')
             megatron_config.update(_convert_config(getattr(config, key), _internal_call=True))
-            if untie_embeddings_and_output_weights is not None:
-                megatron_config['untie_embeddings_and_output_weights'] = untie_embeddings_and_output_weights
+    if untie_embeddings_and_output_weights is not None:
+        megatron_config['untie_embeddings_and_output_weights'] = untie_embeddings_and_output_weights
     # compat llama3
     if getattr(config, 'rope_scaling', None) is not None:
         if isinstance(config.rope_scaling, int):

--- a/src/mcore_bridge/config/parser.py
+++ b/src/mcore_bridge/config/parser.py
@@ -95,7 +95,10 @@ def _convert_config(config, _internal_call=False) -> Dict[str, Any]:
                 break
     for key in ['text_config', 'llm_config', 'thinker_config']:
         if hasattr(config, key):
+            # fix Qwen/Qwen3-VL-30B-A3B-Thinking
+            untie_embeddings_and_output_weights = megatron_config.get('untie_embeddings_and_output_weights')
             megatron_config.update(_convert_config(getattr(config, key), _internal_call=True))
+            megatron_config['untie_embeddings_and_output_weights'] = untie_embeddings_and_output_weights
     # compat llama3
     if getattr(config, 'rope_scaling', None) is not None:
         if isinstance(config.rope_scaling, int):


### PR DESCRIPTION
```
from modelscope import AutoConfig

config = AutoConfig.from_pretrained('Qwen/Qwen3-VL-30B-A3B-Thinking')

print(config.tie_word_embeddings)  # False
print(config.text_config.tie_word_embeddings)  # True
```