### PR TITLE
fix: GDN F.conv1d fallback 缺少 groups 参数 + out_norm 昇腾 NPU 兼容

### DIFF
--- a/src/mcore_bridge/model/gpts/qwen3_next_gdn.py
+++ b/src/mcore_bridge/model/gpts/qwen3_next_gdn.py
@@ -138,8 +138,11 @@ class Qwen3NextLoader(ModelLoader):
         lm_model = model.language_model if hasattr(model, 'language_model') else model
         for layer in lm_model.decoder.layers:
             if hasattr(layer.self_attention, 'out_norm'):
-                assert hasattr(layer.self_attention.out_norm, 'zero_centered_gamma')
-                layer.self_attention.out_norm.zero_centered_gamma = False
+                out_norm = layer.self_attention.out_norm
+                if hasattr(out_norm, 'zero_centered_gamma'):
+                    out_norm.zero_centered_gamma = False
+                elif hasattr(out_norm, 'config'):
+                    out_norm.config.layernorm_zero_centered_gamma = False
         return model
 
 

--- a/src/mcore_bridge/model/modules/gated_delta_net.py
+++ b/src/mcore_bridge/model/modules/gated_delta_net.py
@@ -273,6 +273,7 @@ class GatedDeltaNet(_GatedDeltaNet):
                 stride=self.conv1d.stride,
                 padding=self.conv1d.padding,
                 dilation=self.conv1d.dilation,
+                groups=qkv.shape[1],
             )
             qkv = self.act_fn(conv_out[..., :seq_len])
             qkv = qkv.transpose(1, 2)  # b, d, s -> b, s, d

--- a/src/mcore_bridge/version.py
+++ b/src/mcore_bridge/version.py
@@ -1,5 +1,5 @@
 # Make sure to modify __release_datetime__ to release time when making official release.
-__version__ = '1.4.0.dev0'
+__version__ = '1.4.0'
 # default release datetime for branches under active development is set
 # to be a time far-far-away-into-the-future
-__release_datetime__ = '2099-12-31 23:59:59'
+__release_datetime__ = '2026-05-17 23:59:59'


### PR DESCRIPTION
## 背景

ms-swift (Megatron-SWIFT) 0.16.x + mcore-bridge release/1.4 已支持 Qwen3.5/3.6 系列 GDN（Gated Delta Net）在 NVIDIA GPU 上通过 TransformerEngine + fla 进行 TP/PP 并行训练。但在昇腾 910B3 NPU 上，mcore-bridge 的 F.conv1d 回退路径和模型初始化存在两个问题，导致训练无法运行。

注：NVIDIA 上游 Megatron-Core 的 `gated_delta_net.py` 和 MindSpeed fork 中均已包含 `groups=` 修复，本 PR 使 mcore-bridge 与上游保持一致。

## 问题 1：F.conv1d fallback 缺少 `groups` 参数（gated_delta_net.py）

当 `causal_conv1d` 不可用时（如 fla Triton kernel 在 910B3 上 UB 溢出），代码回退到 `F.conv1d`。但 GDN 中的 conv1d 是**逐通道卷积（depthwise convolution）**，每个通道用独立的滤波器。回退代码缺少 `groups=qkv.shape[1]`，导致：

```
RuntimeError: expected input to have 1 channels, but got 1280 channels
```

这是一个正确性 bug：即使 shape 碰巧匹配，缺少 `groups` 也会导致 PyTorch 将其作为标准卷积（而非逐通道卷积）处理，数学结果错误。

**修复**：添加 `groups=qkv.shape[1]`，与上游 Megatron-Core 保持一致。

## 问题 2：`zero_centered_gamma` assert 在 MindSpeed RMSNorm 下失败（qwen3_next_gdn.py）

模型初始化时，`Qwen3NextLoader` 直接 assert `out_norm` 具有 `zero_centered_gamma` 属性。该属性在 TransformerEngine 的 `FusedLayerNorm` 上存在，但昇腾 NPU 上 MindSpeed 使用自己的 `RMSNorm`，该设置存储在 `config.layernorm_zero_centered_gamma` 中。硬 assert 直接崩溃：

```
AssertionError: assert hasattr(layer.self_attention.out_norm, 'zero_centered_gamma')
```

**修复**：将 assert 替换为鸭子类型检查，同时兼容 TransformerEngine（`out_norm.zero_centered_gamma`）和 MindSpeed RMSNorm（`out_norm.config.layernorm_zero_centered_gamma`）。

## 实测验证

在昇腾 910B3（8x64GB HBM，双机 16 卡）上测试通过：
- 模型：qwen3.6-27B 全量 SFT
- 配置：TP=4, PP=2, max_length=16384, micro_batch_size=1
- 框架：ms-swift (megatron sft) + MindSpeed core_r0.16.0 + mcore-bridge release/1.4
- 结果：两处修复后训练稳定运行。未修复问题 1 时，首个 GDN forward pass 即崩溃；未修复问题 2 时，模型加载阶段即失败。