### PR TITLE
[bugfix] fix: clamp num_tokens=0 in MTP loss & add normalized scale for MTP per token loss

### DIFF
--- a/src/mcore_bridge/model/gpt_model.py
+++ b/src/mcore_bridge/model/gpt_model.py
@@ -413,6 +413,9 @@ class GPTModel(McoreGPTModel):
             if loss_mask is None:
                 # if loss_mask is not provided, use all ones as loss_mask
                 loss_mask = torch.ones_like(mtp_labels)
+            # Capture pre-roll token count so calculate_per_token_loss=True can
+            # re-normalize MTP gradients against the main-loss token count.
+            original_num_tokens = (loss_mask & (mtp_labels != -100)).sum()
             for mtp_layer_number in range(self.config.mtp_unroll_steps):
                 # output
                 mtp_logits = self._forward_output_layer(
@@ -449,10 +452,15 @@ class GPTModel(McoreGPTModel):
                         avg_group=parallel_state.get_data_parallel_group(with_context_parallel=True),
                     )
                 mtp_loss_scale = self.config.mtp_loss_scaling_factor / self.config.mtp_unroll_steps
+                # Clamp to avoid 0/0=NaN when a CP rank's tokens are all rolled out of range.
+                safe_num_tokens = num_tokens.clamp(min=1)
                 if self.config.calculate_per_token_loss:
-                    hidden_states = MTPLossAutoScaler.apply(hidden_states, mtp_loss_scale * mtp_loss)
+                    # finalize_model_grads divides all grads by main-loss total_num_tokens;
+                    # MTP has fewer valid tokens after rolling, so rescale by original_num_tokens.
+                    hidden_states = MTPLossAutoScaler.apply(
+                        hidden_states, mtp_loss_scale * mtp_loss * (original_num_tokens / safe_num_tokens))
                 else:
-                    hidden_states = MTPLossAutoScaler.apply(hidden_states, mtp_loss_scale * mtp_loss / num_tokens)
+                    hidden_states = MTPLossAutoScaler.apply(hidden_states, mtp_loss_scale * mtp_loss / safe_num_tokens)
         sequence_parallel_override = False
         if in_inference_mode and inference_context.materialize_only_last_token_logits:
             if inference_context.is_static_batching():


### PR DESCRIPTION
### What does this PR do?

Fixes a NaN loss bug when using MTP (Multi-Token Prediction) with `context_parallel > 1`, and aligns the MTP gradient normalization with upstream Megatron-LM fixes.

#### Bug: NaN loss when CP > 1 + MTP

When `context_parallel_size > 1`, MTP's `roll_tensor` shifts labels and loss_mask by one position per MTP layer. With CP's load-balanced split, a CP rank may hold only the tail portion of a sequence — after rolling, **all valid tokens can be shifted out of that rank's range**, making `loss_mask_` all-zero on that rank.

This causes:
- `num_tokens = loss_mask_.sum() = 0`
- `mtp_loss / num_tokens = 0 / 0 = NaN`
- NaN propagates through `MTPLossAutoScaler.apply(hidden_states, ...)` into the entire forward graph
- All model gradients become NaN in the backward pass
- Megatron DDP `check_grads` raises: `RuntimeError: found NaN in local grad norm for bucket #0 in backward pass`

**Reproduction**: Qwen3.5-35B-A3B, `--context_parallel_size 2 --mtp_num_layers 1`, DPO training with ms-swift + Megatron-LM. Iteration 0 immediately NaN. Removing either CP or MTP makes it work.

**Fix**: `num_tokens.clamp(min=1)` so `0 / 1 = 0` instead of `0 / 0 = NaN`. Aligned with [NVIDIA/Megatron-LM#3396](https://github.com/NVIDIA/Megatron-LM/pull/3396).

#### Bug: MTP gradient under-weighting with `calculate_per_token_loss=True`

When `calculate_per_token_loss=True`, `finalize_model_grads()` divides **all** gradients (including MTP) by `total_num_tokens` from the main loss (N tokens). But MTP layers use rolled loss masks with fewer valid tokens (M < N), causing systematic under-weighting: `grad_per_token = grad * M/N` instead of `grad`.

**Fix**: Multiply MTP loss by `original_num_tokens / safe_num_tokens` (N/M) before `MTPLossAutoScaler`, so after `finalize_model_grads` divides by N, MTP gradients are correctly weighted. Aligned with [NVIDIA/Megatron-LM#3159](https://github.com/NVIDIA/Megatron-LM/pull/3159).

### References

- [NVIDIA/Megatron-LM#3396](https://github.com/NVIDIA/Megatron-LM/pull/3396) — Fix nan loss caused by zero token in MTP
- [NVIDIA/Megatron-LM#3159](https://github.com/NVIDIA/Megatron-LM/pull/3159) — Add a normalized scale for MTP per token loss
- [verl-project/verl#6464](https://github.com/verl-project/verl/pull/6464) — Same fix in verl

### Checklist

- [x] Search for similar PRs
- [x] Format the PR title as `[{modules}] {type}: {description}`