### PR TITLE
Fix assertion error when packed_seq_params is passed without proper qkv_format

### DIFF
--- a/src/mcore_bridge/model/modules/gated_delta_net.py
+++ b/src/mcore_bridge/model/modules/gated_delta_net.py
@@ -184,7 +184,13 @@ class GatedDeltaNet(_GatedDeltaNet):
             # TODO: support inference
             raise NotImplementedError('GDN does not support inference for now.')
 
-        cu_seqlens = None if packed_seq_params is None else packed_seq_params.cu_seqlens_q
+        # Only use packed sequences when qkv_format is 'thd' and cu_seqlens_q is present
+        cu_seqlens = None
+        if (packed_seq_params is not None and 
+            hasattr(packed_seq_params, 'qkv_format') and 
+            packed_seq_params.qkv_format == 'thd' and
+            packed_seq_params.cu_seqlens_q is not None):
+            cu_seqlens = packed_seq_params.cu_seqlens_q
         # Input projection
         num_key_heads_per_device = self.num_key_heads // self.tp_size // cp_size
         nvtx_range_push(suffix='in_proj')


### PR DESCRIPTION
## 问题描述
即使没有配置 `--reset-attention-mask`，也会有 `packed_seq_params` 被传入，但缺少 `qkv_format` 或 `cu_seqlens_q`，导致 assertion 错误：AssertionError: Packed sequences are not supported when fla is not available.


## 修复方案
修改 `cu_seqlens` 的初始化逻辑，仅在满足以下所有条件时才设置 `cu_seqlens`：
1. `packed_seq_params is not None`
2. `packed_seq_params` 有 `qkv_format` 属性
3. `qkv_format == 'thd'`
4. `cu_seqlens_q is not None`