### PR TITLE
[bugfix] regenerate columnwise data after FP8 weight loading

### DIFF
--- a/src/mcore_bridge/bridge/gpt_bridge.py
+++ b/src/mcore_bridge/bridge/gpt_bridge.py
@@ -215,6 +215,9 @@ class GPTBridge:
                 tensor = tensor.view(torch.uint8)
                 param._rowwise_data.data.copy_(tensor)
                 self._copy_scale_inv(param, hf_scale_inv)
+                # Regenerate columnwise data in-place from freshly-loaded rowwise data
+                if hasattr(param, '_create_columnwise') and param._columnwise_data is not None:
+                    param._create_columnwise()
                 del param.get_high_precision_init_val
         else:
             if hf_scale_inv is not None:


### PR DESCRIPTION
## Summary

- Fix `_set_param()` to regenerate `_columnwise_data` in-place after loading FP8 pre-quantized weights from HuggingFace checkpoints
- Prevents backward dGrad GEMM from reading stale all-zero columnwise data

## Problem

When `fp8_param_gather=True` is used with FP8 pre-quantized models, TE's `reset_parameters()` allocates `_columnwise_data` (all zeros) before checkpoint loading. `_set_param()` then updates only `_rowwise_data`, leaving columnwise stale. TE's `update_usage()` skips regeneration because `_columnwise_data is not None`, causing `general_gemm(layout="NN")` to produce near-zero dGrad.

Detailed discussion in #125

## Changes

`src/mcore_bridge/bridge/gpt_bridge.py`:
- After `_rowwise_data.copy_()`, call `_create_columnwise()` to regenerate columnwise data in-place, reusing the already-allocated buffer

## Tests

Training in FP8 with original mcore-bridge:

<img width="1390" height="602" alt="Image" src="https://github.com/user-attachments/assets/345c02c2-c738-4f13-80f3-9d368066faea" />

Training in FP8 with our fix:

<img width="1388" height="427" alt="Image" src="https://github.com/user-attachments/assets/8c0f0212-bce2-4c25-8f30-c8b04e056496" />

Training in BF16 with original mcore-bridge:

<img width="1389" height="597" alt="Image" src="https://github.com/user-attachments/assets/4e7de075-bcaa-4d8b-b264-6566356dfda0" />