### PR TITLE
[bugfix] fix multi-LoRA load assertion failure on idle adapter slots

### DIFF
--- a/src/mcore_bridge/bridge/gpt_bridge.py
+++ b/src/mcore_bridge/bridge/gpt_bridge.py
@@ -270,9 +270,12 @@ class GPTBridge:
             incompatible_keys = mg_module.load_state_dict(hf_state_dict, strict=False)
             missing_keys = incompatible_keys.missing_keys
             if self._peft_format:
+                # In multi-LoRA mode, only the current adapter slot is saved/loaded.
+                # Other idle slots (e.g. lora_1~N) are not in the checkpoint and
+                # their absence is expected — only validate the active adapter.
                 missing_keys = [
-                    k for k in incompatible_keys.missing_keys
-                    if '.lora_A.' in k or '.lora_B.' in k or '.modules_to_save.' in k
+                    k for k in incompatible_keys.missing_keys if
+                    ('.lora_A.' in k or '.lora_B.' in k or '.modules_to_save.' in k) and f'.{self._adapter_name}.' in k
                 ]
             assert len(missing_keys) == 0, f'incompatible_keys.missing_keys: {missing_keys}'
             return {}


### PR DESCRIPTION
## Problem

In multi-LoRA mode (e.g. 5 adapter slots: `lora_0` - `lora_4`), `save()` only persists the active adapter's weights (e.g. `lora_0`). When `load()` is called to reload a checkpoint, the `missing_keys` assertion in `GPTBridge._set_module()` incorrectly checks ALL LoRA-related keys, causing an `AssertionError` because idle slots (`lora_1` - `lora_4`) are naturally not in the checkpoint.

```
AssertionError: incompatible_keys.missing_keys: ['blocks.0.attn.qkv.lora_A.lora_1.weight', ...]
```

## Root Cause

The filter at line 273-276 only checks if a key contains `.lora_A.` / `.lora_B.` / `.modules_to_save.`, but does not distinguish between the adapter being loaded vs other idle slots:

```python
missing_keys = [
    k for k in incompatible_keys.missing_keys
    if '.lora_A.' in k or '.lora_B.' in k or '.modules_to_save.' in k
]
```

## Fix

Add `f'.{self._adapter_name}.' in k` to only validate keys belonging to the current adapter slot being loaded:

```python
missing_keys = [
    k for k in incompatible_keys.missing_keys
    if ('.lora_A.' in k or '.lora_B.' in k or '.modules_to_save.' in k)
    and f'.{self._adapter_name}.' in k
]
```

This is safe because:
- Each adapter is saved/loaded independently
- `self._adapter_name` identifies the target slot (e.g. `lora_0`)
- If the checkpoint is incomplete for the target adapter, the assert still fires correctly
- Idle slots being absent from checkpoint is expected behavior, not an error

## Reproduction

1. Start Megatron backend with multi-LoRA config (5 slots)
2. Train and call `model.save(name)`
3. Call `model.load(name)` -> **AssertionError** on lora_1~4 missing keys

## Affected Versions

Tested on mcore-bridge 1.1.0 ~ 1.5.1 (logic unchanged across versions).