### PR TITLE
[bugfix] skip full-size cat copy when single shard (TP==1) to avoid OOM

### DIFF
--- a/src/mcore_bridge/bridge/gpt_bridge.py
+++ b/src/mcore_bridge/bridge/gpt_bridge.py
@@ -409,9 +409,13 @@ class GPTBridge:
                 tensor = [t._rowwise_data for t in tensor]
             del mg_weight
             assert isinstance(tensor, (list, tuple)), f'mg_key: {mg_key}'
-            tensor = torch.concat(tensor, dim=0)
+            # Skip full-size cat copy when single shard (TP==1) to avoid OOM in colocate sync
+            tensor = tensor[0] if len(tensor) == 1 else torch.concat(tensor, dim=0)
             if mg_scale_inv is not None:
-                mg_scale_inv = torch.concat(mg_scale_inv, dim=0)
+                mg_scale_inv = (
+                    mg_scale_inv[0] if isinstance(mg_scale_inv,
+                                                  (list, tuple)) and len(mg_scale_inv) == 1 else torch.concat(
+                                                      mg_scale_inv, dim=0))
         num_local_experts = self.config.num_moe_experts // self.ep_size if is_expert else 1
         tp_dim = self._get_tp_split_dim(mg_key)
         is_linear_fc1 = (mg_key is not None and mg_key.split('.', 1)[0] == 'linear_fc1' and tp_dim is not None)

--- a/src/mcore_bridge/bridge/gpt_bridge.py
+++ b/src/mcore_bridge/bridge/gpt_bridge.py
@@ -412,10 +412,7 @@ class GPTBridge:
             # Skip full-size cat copy when single shard (TP==1) to avoid OOM in colocate sync
             tensor = tensor[0] if len(tensor) == 1 else torch.concat(tensor, dim=0)
             if mg_scale_inv is not None:
-                mg_scale_inv = (
-                    mg_scale_inv[0] if isinstance(mg_scale_inv,
-                                                  (list, tuple)) and len(mg_scale_inv) == 1 else torch.concat(
-                                                      mg_scale_inv, dim=0))
+                mg_scale_inv = mg_scale_inv[0] if len(mg_scale_inv) == 1 else torch.concat(mg_scale_inv, dim=0)
         num_local_experts = self.config.num_moe_experts // self.ep_size if is_expert else 1
         tp_dim = self._get_tp_split_dim(mg_key)
         is_linear_fc1 = (mg_key is not None and mg_key.split('.', 1)[0] == 'linear_fc1' and tp_dim is not None)


### PR DESCRIPTION
## What does this PR do?

This PR fixes an OOM (out-of-memory) issue that occurs during colocate sync when tensor parallelism size is 1 (single shard).

## Problem

In `_get_weight`, `torch.concat(tensor, dim=0)` was always called regardless of the number of shards. When there is only a single shard (TP==1), this still allocates a new full-size tensor copy, causing unnecessary peak GPU memory spikes that lead to OOM in the colocate sync path.

## Fix

Skip the `torch.concat` copy when the shard list contains a single element:

- For `tensor`: directly use `tensor[0]` when `len(tensor) == 1`, otherwise concatenate as before.
- For `mg_scale_inv`: apply the same single-shard shortcut (only when it is a list/tuple of length 1).

This removes one redundant full-size tensor copy in the TP==1 path, reducing peak GPU memory usage.

## Changes

- `src/mcore_bridge/bridge/gpt_bridge.py`: updated the shard-merging logic in `_get_weight` to short-circuit on single-shard inputs.