### PR TITLE
[model] optimize padding mask reduction memory

### DIFF
--- a/src/mcore_bridge/model/gpt_model.py
+++ b/src/mcore_bridge/model/gpt_model.py
@@ -300,7 +300,7 @@ class GPTModel(McoreGPTModel):
             full_attention_mask = full_attention_mask['full_attention']
         if mcore_016 and full_attention_mask is not None:
             assert packed_seq_params is None
-            padding_mask = ~((~full_attention_mask).sum(dim=(1, 2)) > 0)
+            padding_mask = full_attention_mask.all(dim=(1, 2))
             if self.config.context_parallel_size > 1:
                 padding_mask = split_cp_inputs(padding_mask, None, 1)
             tp_size = self.config.tensor_model_parallel_size

--- a/src/mcore_bridge/model/hybrid_model.py
+++ b/src/mcore_bridge/model/hybrid_model.py
@@ -59,7 +59,7 @@ class HybridModel(McoreHybridModel):
             attention_mask = attention_mask['full_attention']
         if attention_mask is None:
             return None
-        padding_mask = ~((~attention_mask).sum(dim=(1, 2)) > 0)
+        padding_mask = attention_mask.all(dim=(1, 2))
         if self.config.context_parallel_size > 1:
             padding_mask = split_cp_inputs(padding_mask, None, 1)
         tp_size = self.config.tensor_model_parallel_size


### PR DESCRIPTION
For a 128K sequence length, calling .sum() on the boolean attention mask promotes it to int64, resulting in a temporary tensor exceeding 90 GB.
Replace it with the logically equivalent Tensor.all() operation, which performs a native boolean reduction and avoids the large temporary allocation.
