### PR TITLE
[bugfix] fix GDN sequence_parallel not effective on LoraParallelLinear

### DIFF
--- a/src/mcore_bridge/tuners/lora.py
+++ b/src/mcore_bridge/tuners/lora.py
@@ -581,3 +581,15 @@ class LoraParallelLinear(MegatronModule, LoraLayer):
 
         if origin_device.type == 'cpu':
             self.to(device=origin_device)
+
+    @property
+    def sequence_parallel(self):
+        return self.base_layer.sequence_parallel
+
+    @sequence_parallel.setter
+    def sequence_parallel(self, value: bool):
+        self.base_layer.sequence_parallel = value
+        for adapter in self.lora_A.keys():
+            self.lora_A[adapter].sequence_parallel = value
+        for adapter in self.lora_B.keys():
+            self.lora_B[adapter].sequence_parallel = value


### PR DESCRIPTION
## Summary
Fix #169.

Add a `sequence_parallel` property on `LoraParallelLinear` that delegates reads/writes to `base_layer` and all `lora_A` / `lora_B` adapters, so `_set_linear_sequence_parallel` / `_restore_linear_sequence_parallel` in `GatedDeltaNet` take effect on LoRA-wrapped linears.

Note: this works, but the approach feels a bit dirty (proxying inner modules' attribute via a property on the wrapper). Opened as a **Draft PR** — suggestions for a cleaner implementation are welcome.
