### PR TITLE
fix: make Nemotron-H import error adaption on Megatron-Core 0.16.1

### DIFF
--- a/src/mcore_bridge/model/gpts/__init__.py
+++ b/src/mcore_bridge/model/gpts/__init__.py
@@ -1,8 +1,3 @@
 # Copyright (c) ModelScope Contributors. All rights reserved.
-from importlib.util import find_spec
-
-from . import (bailing_hybrid, bailing_moe, deepseek_v4, glm4, glm_moe_dsa, hunyuan, llm, minimax_m2, olmoe, qwen3_emb,
-               qwen3_next)
-
-if find_spec('megatron.core.models.hybrid') is not None:
-    from . import nemotron_h
+from . import (bailing_hybrid, bailing_moe, deepseek_v4, glm4, glm_moe_dsa, hunyuan, llm, minimax_m2, nemotron_h, olmoe,
+               qwen3_emb, qwen3_next)

--- a/src/mcore_bridge/model/gpts/__init__.py
+++ b/src/mcore_bridge/model/gpts/__init__.py
@@ -1,3 +1,8 @@
 # Copyright (c) ModelScope Contributors. All rights reserved.
-from . import (bailing_hybrid, bailing_moe, deepseek_v4, glm4, glm_moe_dsa, hunyuan, llm, minimax_m2, nemotron_h, olmoe,
-               qwen3_emb, qwen3_next)
+from importlib.util import find_spec
+
+from . import (bailing_hybrid, bailing_moe, deepseek_v4, glm4, glm_moe_dsa, hunyuan, llm, minimax_m2, olmoe, qwen3_emb,
+               qwen3_next)
+
+if find_spec('megatron.core.models.hybrid') is not None:
+    from . import nemotron_h

--- a/src/mcore_bridge/model/gpts/nemotron_h.py
+++ b/src/mcore_bridge/model/gpts/nemotron_h.py
@@ -9,8 +9,6 @@ and MTP can span several heterogeneous inner layers.
 import torch
 from megatron.core.extensions.transformer_engine import TEColumnParallelLinear, TENorm, TERowParallelLinear
 from megatron.core.fusions.fused_bias_dropout import get_bias_dropout_add
-from megatron.core.models.hybrid.hybrid_block import HybridStack, HybridStackSubmodules
-from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
 from megatron.core.ssm.mamba_layer import MambaLayer, MambaLayerSubmodules
 from megatron.core.ssm.mamba_mixer import MambaMixer, MambaMixerSubmodules
 from megatron.core.transformer.spec_utils import ModuleSpec
@@ -21,8 +19,20 @@ from mcore_bridge.tuners import LoraParallelLinear
 from mcore_bridge.utils import get_logger
 
 from ..constant import ModelType
-from ..hybrid_model import HybridModel
 from ..register import ModelLoader, ModelMeta, register_model
+
+try:
+    from megatron.core.models.hybrid.hybrid_block import HybridStack, HybridStackSubmodules
+    from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
+
+    from ..hybrid_model import HybridModel
+
+    _HYBRID_MODEL_AVAILABLE = True
+except ImportError as error:
+    if not (error.name or '').startswith('megatron.core.models.hybrid'):
+        raise
+    HybridModel = HybridStack = HybridStackSubmodules = hybrid_stack_spec = None
+    _HYBRID_MODEL_AVAILABLE = False
 
 logger = get_logger()
 
@@ -410,9 +420,11 @@ class NemotronHLoader(ModelLoader):
         return model
 
 
-register_model(ModelMeta(
-    ModelType.nemotron_h,
-    ['nemotron_h'],
-    bridge_cls=NemotronHBridge,
-    loader=NemotronHLoader,
-))
+if _HYBRID_MODEL_AVAILABLE:
+    register_model(
+        ModelMeta(
+            ModelType.nemotron_h,
+            ['nemotron_h'],
+            bridge_cls=NemotronHBridge,
+            loader=NemotronHLoader,
+        ))


### PR DESCRIPTION
Make Nemotron-H registration conditional when the installed Megatron-Core does not provide megatron.core.models.hybrid. On Ascend A3 with Megatron-Core 0.16.1 and USE_MCORE_GDN=0, the training initialization import passed and Nemotron-H was correctly skipped.