### PR TITLE
Fix packed sequence length handling for Megatron-Core 0.16.0/0.16.1

### DIFF
--- a/src/mcore_bridge/model/gpts/__init__.py
+++ b/src/mcore_bridge/model/gpts/__init__.py
@@ -1,8 +1,3 @@
 # Copyright (c) ModelScope Contributors. All rights reserved.
-from importlib.util import find_spec
-
-from . import (bailing_hybrid, bailing_moe, deepseek_v4, glm4, glm_moe_dsa, hunyuan, llm, minimax_m2, olmoe, qwen3_emb,
-               qwen3_next)
-
-if find_spec('megatron.core.models.hybrid') is not None:
-    from . import nemotron_h
+from . import (bailing_hybrid, bailing_moe, deepseek_v4, glm4, glm_moe_dsa, hunyuan, llm, minimax_m2, nemotron_h, olmoe,
+               qwen3_emb, qwen3_next)

--- a/src/mcore_bridge/model/gpts/__init__.py
+++ b/src/mcore_bridge/model/gpts/__init__.py
@@ -1,3 +1,8 @@
 # Copyright (c) ModelScope Contributors. All rights reserved.
-from . import (bailing_hybrid, bailing_moe, deepseek_v4, glm4, glm_moe_dsa, hunyuan, llm, minimax_m2, nemotron_h, olmoe,
-               qwen3_emb, qwen3_next)
+from importlib.util import find_spec
+
+from . import (bailing_hybrid, bailing_moe, deepseek_v4, glm4, glm_moe_dsa, hunyuan, llm, minimax_m2, olmoe, qwen3_emb,
+               qwen3_next)
+
+if find_spec('megatron.core.models.hybrid') is not None:
+    from . import nemotron_h

--- a/src/mcore_bridge/model/gpts/nemotron_h.py
+++ b/src/mcore_bridge/model/gpts/nemotron_h.py
@@ -9,8 +9,6 @@ and MTP can span several heterogeneous inner layers.
 import torch
 from megatron.core.extensions.transformer_engine import TEColumnParallelLinear, TENorm, TERowParallelLinear
 from megatron.core.fusions.fused_bias_dropout import get_bias_dropout_add
-from megatron.core.models.hybrid.hybrid_block import HybridStack, HybridStackSubmodules
-from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
 from megatron.core.ssm.mamba_layer import MambaLayer, MambaLayerSubmodules
 from megatron.core.ssm.mamba_mixer import MambaMixer, MambaMixerSubmodules
 from megatron.core.transformer.spec_utils import ModuleSpec
@@ -21,8 +19,20 @@ from mcore_bridge.tuners import LoraParallelLinear
 from mcore_bridge.utils import get_logger
 
 from ..constant import ModelType
-from ..hybrid_model import HybridModel
 from ..register import ModelLoader, ModelMeta, register_model
+
+try:
+    from megatron.core.models.hybrid.hybrid_block import HybridStack, HybridStackSubmodules
+    from megatron.core.models.hybrid.hybrid_layer_specs import hybrid_stack_spec
+
+    from ..hybrid_model import HybridModel
+
+    _HYBRID_MODEL_AVAILABLE = True
+except ImportError as error:
+    if not (error.name or '').startswith('megatron.core.models.hybrid'):
+        raise
+    HybridModel = HybridStack = HybridStackSubmodules = hybrid_stack_spec = None
+    _HYBRID_MODEL_AVAILABLE = False
 
 logger = get_logger()
 
@@ -410,9 +420,11 @@ class NemotronHLoader(ModelLoader):
         return model
 
 
-register_model(ModelMeta(
-    ModelType.nemotron_h,
-    ['nemotron_h'],
-    bridge_cls=NemotronHBridge,
-    loader=NemotronHLoader,
-))
+if _HYBRID_MODEL_AVAILABLE:
+    register_model(
+        ModelMeta(
+            ModelType.nemotron_h,
+            ['nemotron_h'],
+            bridge_cls=NemotronHBridge,
+            loader=NemotronHLoader,
+        ))

--- a/src/mcore_bridge/model/gpts/qwen3_next.py
+++ b/src/mcore_bridge/model/gpts/qwen3_next.py
@@ -474,8 +474,7 @@ class Qwen3NextGatedDeltaNet(_HuggingFaceModule, _Qwen3NextGatedDeltaNet):
             max_seqlen_q = int(packed_seq_params.max_seqlen_q)
             new_hidden_states = hidden_states.new_zeros(
                 (packed_seq_params.num_samples, max_seqlen_q, hidden_states.shape[-1]))
-            attention_mask = hidden_states.new_zeros(
-                (packed_seq_params.num_samples, max_seqlen_q), dtype=torch.bool)
+            attention_mask = hidden_states.new_zeros((packed_seq_params.num_samples, max_seqlen_q), dtype=torch.bool)
             cu_seqlens_q = packed_seq_params.cu_seqlens_q
             for i in range(packed_seq_params.num_samples):
                 start, end = cu_seqlens_q[i], cu_seqlens_q[i + 1]

--- a/src/mcore_bridge/model/gpts/qwen3_next.py
+++ b/src/mcore_bridge/model/gpts/qwen3_next.py
@@ -471,10 +471,11 @@ class Qwen3NextGatedDeltaNet(_HuggingFaceModule, _Qwen3NextGatedDeltaNet):
         # Note: for packed inputs, we do not perform padding_free unpadding.
         # Doing so would allow different sequences to see each other; for efficiency we keep this implementation.
         if thd_format:
+            max_seqlen_q = int(packed_seq_params.max_seqlen_q)
             new_hidden_states = hidden_states.new_zeros(
-                (packed_seq_params.num_samples, packed_seq_params.max_seqlen_q.item(), hidden_states.shape[-1]))
+                (packed_seq_params.num_samples, max_seqlen_q, hidden_states.shape[-1]))
             attention_mask = hidden_states.new_zeros(
-                (packed_seq_params.num_samples, packed_seq_params.max_seqlen_q.item()), dtype=torch.bool)
+                (packed_seq_params.num_samples, max_seqlen_q), dtype=torch.bool)
             cu_seqlens_q = packed_seq_params.cu_seqlens_q
             for i in range(packed_seq_params.num_samples):
                 start, end = cu_seqlens_q[i], cu_seqlens_q[i + 1]

--- a/src/mcore_bridge/model/mm_gpts/qwen3_5.py
+++ b/src/mcore_bridge/model/mm_gpts/qwen3_5.py
@@ -43,8 +43,7 @@ class Qwen3_5MoeGatedDeltaNet(_HuggingFaceModule, _Qwen3_5MoeGatedDeltaNet):
             max_seqlen_q = int(packed_seq_params.max_seqlen_q)
             new_hidden_states = hidden_states.new_zeros(
                 (packed_seq_params.num_samples, max_seqlen_q, hidden_states.shape[-1]))
-            attention_mask = hidden_states.new_zeros(
-                (packed_seq_params.num_samples, max_seqlen_q), dtype=torch.bool)
+            attention_mask = hidden_states.new_zeros((packed_seq_params.num_samples, max_seqlen_q), dtype=torch.bool)
             cu_seqlens_q = packed_seq_params.cu_seqlens_q
             for i in range(packed_seq_params.num_samples):
                 start, end = cu_seqlens_q[i], cu_seqlens_q[i + 1]

--- a/src/mcore_bridge/model/mm_gpts/qwen3_5.py
+++ b/src/mcore_bridge/model/mm_gpts/qwen3_5.py
@@ -40,10 +40,11 @@ class Qwen3_5MoeGatedDeltaNet(_HuggingFaceModule, _Qwen3_5MoeGatedDeltaNet):
         # Note: for packed inputs, we do not perform padding_free unpadding.
         # Doing so would allow different sequences to see each other; for efficiency we keep this implementation.
         if thd_format:
+            max_seqlen_q = int(packed_seq_params.max_seqlen_q)
             new_hidden_states = hidden_states.new_zeros(
-                (packed_seq_params.num_samples, packed_seq_params.max_seqlen_q.item(), hidden_states.shape[-1]))
+                (packed_seq_params.num_samples, max_seqlen_q, hidden_states.shape[-1]))
             attention_mask = hidden_states.new_zeros(
-                (packed_seq_params.num_samples, packed_seq_params.max_seqlen_q.item()), dtype=torch.bool)
+                (packed_seq_params.num_samples, max_seqlen_q), dtype=torch.bool)
             cu_seqlens_q = packed_seq_params.cu_seqlens_q
             for i in range(packed_seq_params.num_samples):
                 start, end = cu_seqlens_q[i], cu_seqlens_q[i + 1]


### PR DESCRIPTION
## Why

In Megatron-Core 0.16.0/0.16.1, `PackedSeqParams.max_seqlen_q` is defined as a Python `int`. The Qwen3.5 and Qwen3-Next THD packed-sequence paths called `.item()` on this value, causing:
`AttributeError: 'int' object has no attribute 'item'`

## Changes

Convert `max_seqlen_q` with `int(...)` before allocating hidden states and attention masks. This supports both Python integers and scalar tensors without changing numerical computation.

## Validation

- Qwen3.5 training ran successfully for multiple steps on A3 with Megatron-Core 0.16.1.
- Python compilation checks passed for both modified files.
- Python `int` and scalar Tensor conversion cases passed.

## GPU Compatibility

This change is device-agnostic and remains compatible with GPU training. `max_seqlen_q` is sequence-length metadata used only to construct tensor shapes; converting it with `int(...)` works with both Python integers and single-element CPU/CUDA/NPU tensors.

## Experiments

<img width="785" height="476" alt="截屏2026-08-29 下午4 10 28" src="https://github.com/user-attachments/assets/9dd43c63-ede8-46a2-9aab-646be059265b" />
Qwen3.5 training loss decreased and converged as expected.
The change is also compatible with Megatron-Core 0.16.0–0.19.x, where `max_seqlen_q` remains integer metadata. Using `int(...)` supports both Python integers and scalar tensors without affecting model computation.