### PR TITLE
fix: support QSA with sequence parallelism

### DIFF
--- a/src/mcore_bridge/model/gpts/qwen4_exp.py
+++ b/src/mcore_bridge/model/gpts/qwen4_exp.py
@@ -58,7 +58,7 @@ class Qwen4ExpLayer(TransformerLayer):
                 config, config.ple_layer_ids.index(self.layer_number), pg_collection=self.pg_collection)
         is_linear_attention = config.linear_attention_freq[self.layer_number - 1]
         if not is_linear_attention and getattr(config, 'indexer_n_heads', None) is not None:
-            self.self_attention.indexer = QSAIndexer(config)
+            self.self_attention.indexer = QSAIndexer(config, tp_group=self.tp_group)
         self.attn_hyper_connection = Qwen4ExpTextGatedResidual(config)
         self.mlp_hyper_connection = Qwen4ExpTextGatedResidual(config)
 

--- a/src/mcore_bridge/model/modules/qsa_indexer.py
+++ b/src/mcore_bridge/model/modules/qsa_indexer.py
@@ -67,10 +67,11 @@ class QSAIndexer(nn.Module):
             hidden_states: ``[s, b, h]`` (mcore layout), pre-attention input --
                 the same tensor the reference indexer consumes. ``s`` is the
                 local sequence length when sequence parallelism is enabled.
-            freqs: mcore rotary frequencies ``[s, 1, 1, rot_dim]``. mcore stores
-                angles rather than cos/sin, so they are materialized here the way
-                ``_patch_apply_rotary_pos_emb`` does (``cos(freqs) * mscale``),
-                keeping the indexer's RoPE identical to the attention's.
+            freqs: Full-sequence mcore rotary frequencies
+                ``[S, 1, 1, rot_dim]``. mcore stores angles rather than cos/sin,
+                so they are materialized here the way ``_patch_apply_rotary_pos_emb``
+                does (``cos(freqs) * mscale``), keeping the indexer's RoPE identical
+                to the attention's.
 
         Returns:
             ``[b, 1, s, s]`` bool mask where True marks a *masked-out* key (TE's
@@ -82,7 +83,12 @@ class QSAIndexer(nn.Module):
         for packed/THD or context-parallel inputs (see the guard in the layer).
         """
         local_s, b, _ = hidden_states.shape
-        tp_size = self.config.tensor_model_parallel_size if self.config.sequence_parallel else 1
+        if self.config.sequence_parallel:
+            if self.tp_group is None:
+                raise RuntimeError('QSA sequence parallelism requires a tensor-parallel process group.')
+            tp_size = self.tp_group.size()
+        else:
+            tp_size = 1
         s = local_s * tp_size
         R = self.compress_ratio
         max_blocks = s // R
@@ -102,7 +108,8 @@ class QSAIndexer(nn.Module):
         qk = self.index_qk_proj(hidden_states)
         if tp_size > 1:
             qk = gather_from_sequence_parallel_region(qk, tensor_parallel_output_grad=False, group=self.tp_group)
-        assert qk.shape[0] == s, f'QSA indexer expected sequence length {s}, got {qk.shape[0]}'
+        if qk.shape[0] != s:
+            raise RuntimeError(f'QSA indexer expected sequence length {s}, got {qk.shape[0]}.')
         q, token_k = torch.split(
             qk, [self.index_n_heads * self.index_head_dim, self.index_kv_heads * self.index_head_dim], dim=-1)
         # -> [b, s, nh, d] / [b, s, d]

--- a/src/mcore_bridge/model/modules/qsa_indexer.py
+++ b/src/mcore_bridge/model/modules/qsa_indexer.py
@@ -67,11 +67,10 @@ class QSAIndexer(nn.Module):
             hidden_states: ``[s, b, h]`` (mcore layout), pre-attention input --
                 the same tensor the reference indexer consumes. ``s`` is the
                 local sequence length when sequence parallelism is enabled.
-            freqs: Full-sequence mcore rotary frequencies
-                ``[S, 1, 1, rot_dim]``. mcore stores angles rather than cos/sin,
-                so they are materialized here the way ``_patch_apply_rotary_pos_emb``
-                does (``cos(freqs) * mscale``), keeping the indexer's RoPE identical
-                to the attention's.
+            freqs: mcore rotary frequencies ``[s, 1, 1, rot_dim]``. mcore stores
+                angles rather than cos/sin, so they are materialized here the way
+                ``_patch_apply_rotary_pos_emb`` does (``cos(freqs) * mscale``),
+                keeping the indexer's RoPE identical to the attention's.
 
         Returns:
             ``[b, 1, s, s]`` bool mask where True marks a *masked-out* key (TE's
@@ -83,12 +82,7 @@ class QSAIndexer(nn.Module):
         for packed/THD or context-parallel inputs (see the guard in the layer).
         """
         local_s, b, _ = hidden_states.shape
-        if self.config.sequence_parallel:
-            if self.tp_group is None:
-                raise RuntimeError('QSA sequence parallelism requires a tensor-parallel process group.')
-            tp_size = self.tp_group.size()
-        else:
-            tp_size = 1
+        tp_size = self.config.tensor_model_parallel_size if self.config.sequence_parallel else 1
         s = local_s * tp_size
         R = self.compress_ratio
         max_blocks = s // R
@@ -108,8 +102,7 @@ class QSAIndexer(nn.Module):
         qk = self.index_qk_proj(hidden_states)
         if tp_size > 1:
             qk = gather_from_sequence_parallel_region(qk, tensor_parallel_output_grad=False, group=self.tp_group)
-        if qk.shape[0] != s:
-            raise RuntimeError(f'QSA indexer expected sequence length {s}, got {qk.shape[0]}.')
+        assert qk.shape[0] == s, f'QSA indexer expected sequence length {s}, got {qk.shape[0]}'
         q, token_k = torch.split(
             qk, [self.index_n_heads * self.index_head_dim, self.index_kv_heads * self.index_head_dim], dim=-1)
         # -> [b, s, nh, d] / [b, s, d]

--- a/src/mcore_bridge/model/modules/qsa_indexer.py
+++ b/src/mcore_bridge/model/modules/qsa_indexer.py
@@ -1,6 +1,7 @@
 # Copyright (c) ModelScope Contributors. All rights reserved.
 import math
 import torch
+from megatron.core.tensor_parallel import gather_from_sequence_parallel_region
 from torch import nn
 
 
@@ -28,9 +29,10 @@ def _rotate_half(x: torch.Tensor) -> torch.Tensor:
 
 class QSAIndexer(nn.Module):
     # refer: transformers Qwen4ExpTextQSAIndexer
-    def __init__(self, config):
+    def __init__(self, config, tp_group=None):
         super().__init__()
         self.config = config
+        self.tp_group = tp_group
         self.index_n_heads = config.indexer_n_heads
         self.index_kv_heads = config.indexer_kv_heads
         self.index_head_dim = config.indexer_head_dim
@@ -63,7 +65,8 @@ class QSAIndexer(nn.Module):
 
         Args:
             hidden_states: ``[s, b, h]`` (mcore layout), pre-attention input --
-                the same tensor the reference indexer consumes.
+                the same tensor the reference indexer consumes. ``s`` is the
+                local sequence length when sequence parallelism is enabled.
             freqs: mcore rotary frequencies ``[s, 1, 1, rot_dim]``. mcore stores
                 angles rather than cos/sin, so they are materialized here the way
                 ``_patch_apply_rotary_pos_emb`` does (``cos(freqs) * mscale``),
@@ -78,7 +81,9 @@ class QSAIndexer(nn.Module):
         Only the causal, unpacked layout is handled; callers must not invoke this
         for packed/THD or context-parallel inputs (see the guard in the layer).
         """
-        s, b, _ = hidden_states.shape
+        local_s, b, _ = hidden_states.shape
+        tp_size = self.config.tensor_model_parallel_size if self.config.sequence_parallel else 1
+        s = local_s * tp_size
         R = self.compress_ratio
         max_blocks = s // R
         # Selection is a no-op while the causal prefix never exceeds the budget:
@@ -90,8 +95,14 @@ class QSAIndexer(nn.Module):
 
         device = hidden_states.device
         # ---- project to indexer q/k ----
-        # [s, b, h] -> [s, b, (nh + nkv) * d]
+        # Project the local SP shard first, then gather only the compact indexer
+        # activations. For Qwen3.8-Flash-Next this communicates 640 values/token
+        # instead of gathering all 2560 hidden values/token.
+        # [local_s, b, h] -> [local_s, b, (nh + nkv) * d]
         qk = self.index_qk_proj(hidden_states)
+        if tp_size > 1:
+            qk = gather_from_sequence_parallel_region(qk, tensor_parallel_output_grad=False, group=self.tp_group)
+        assert qk.shape[0] == s, f'QSA indexer expected sequence length {s}, got {qk.shape[0]}'
         q, token_k = torch.split(
             qk, [self.index_n_heads * self.index_head_dim, self.index_kv_heads * self.index_head_dim], dim=-1)
         # -> [b, s, nh, d] / [b, s, d]


### PR DESCRIPTION
## Summary

- project each local sequence-parallel shard with the replicated QSA indexer before communication
- all-gather the compact indexer Q/K activations across the layer TP group
- build the QSA mask from the restored full sequence so it matches TE's full-sequence Q/K/V
- preserve the existing packed-sequence and context-parallel fallbacks

For Qwen3.8-Flash-Next, the gathered width is 640 (`(4 + 1) * 128`) instead of the 2560-wide hidden state, reducing the new communication volume by 75% compared with gathering `hidden_states` directly.

Fixes #178.

## Validation

- verified with a real 2-process Gloo collective that both TP ranks produce a mask identical to the non-SP full-sequence path, including a pooling block crossing the rank boundary
- verified that globally short sequences still return `None` before projection or communication
- verified the gather API and first-dimension concatenation semantics against Megatron-Core 0.16.0, 0.16.1, 0.17.0, 0.18.0, and 0.19.0
- `pre-commit run --all-files`
- `python3 -m py_compile src/mcore_bridge/model/gpts/qwen4_exp.py src/mcore_bridge/model/modules/qsa_indexer.py`

The validation harness was intentionally not committed; this PR contains production code only.
