### PR TITLE
fix(qwen4_exp): fall back QSA to full attention under sequence parallelism

### DIFF
--- a/src/mcore_bridge/model/gpts/qwen4_exp.py
+++ b/src/mcore_bridge/model/gpts/qwen4_exp.py
@@ -151,6 +151,16 @@ class Qwen4ExpLayer(TransformerLayer):
                 'back to full attention -- training will differ from sparse inference beyond the '
                 'indexer budget.')
             return None
+        if getattr(self.config, 'sequence_parallel', False) and self.config.tensor_model_parallel_size > 1:
+            # Under SP the indexer would see SP-sharded hidden states (s/tp) while TE core
+            # attention runs on the all-gathered full sequence, so the [b, 1, s, s] selection
+            # mask would not match the q/k length (logical_or shape error in the unfused path).
+            self._warn_qsa_fallback_once(
+                'sequence_parallel is enabled: the QSA indexer consumes SP-sharded hidden states '
+                'while core attention runs on the full sequence. QSA layers fall back to full '
+                'attention -- training will differ from sparse inference beyond the indexer '
+                'budget.')
+            return None
         rotary_pos_emb = attn_kwargs.get('rotary_pos_emb')
         if rotary_pos_emb is None:
             return None


### PR DESCRIPTION
Related to #178.

With `sequence_parallel=True` and TP>1, the QSA indexer consumes
SP-sharded hidden states (s/tp) while TE core attention runs on the
all-gathered full sequence. The `[b, 1, s, s]` selection mask then
mismatches q/k length and the unfused path crashes on `logical_or`.
This is a parallel-layout bug; bf16 and FP8 both hit it.

QSA layers now fall back to full attention in this config, with a
one-time warning that training beyond the indexer budget differs
from sparse inference — same pattern as the packing/padding_free
and CP fallbacks above it.

This is a safety fallback, not an SP-aware QSA. Sequences longer
than the indexer budget (2048) are trained with dense attention.

Verified: Megatron LoRA SFT, Qwen3.8-Flash-Next-FP8, 2 GPU
(TP=2+SP, EP=2, ETP=1, PP=1, CP=1). Training proceeds with the
fallback active.